### PR TITLE
OADP-598: Improve datamover backup performance via updating the blocking condition

### DIFF
--- a/internal/backup/volumesnapshotbackup_action.go
+++ b/internal/backup/volumesnapshotbackup_action.go
@@ -34,7 +34,7 @@ func (p *VolumeSnapshotBackupBackupItemAction) Execute(item runtime.Unstructured
 		return nil, nil, errors.WithStack(err)
 	}
 	p.Log.Infof("Converted Item to VSB: %v", vsb)
-	vsbNew, err := util.GetVolumeSnapshotbackupWithCompletedStatus(vsb.Namespace, vsb.Name, p.Log)
+	vsbNew, err := util.GetVolumeSnapshotbackupWithStatusData(vsb.Namespace, vsb.Name, p.Log)
 
 	if err != nil {
 		return nil, nil, errors.WithStack(err)

--- a/internal/restore/volumesnapshotrestore_action.go
+++ b/internal/restore/volumesnapshotrestore_action.go
@@ -70,6 +70,11 @@ func (p *VolumeSnapshotRestoreRestoreItemAction) Execute(input *velero.RestoreIt
 		},
 	}
 
+	// if namespace mapping is specified
+	if val, ok := input.Restore.Spec.NamespaceMapping[vsr.GetNamespace()]; ok {
+		vsr.SetNamespace(val)
+	}
+
 	err = snapMoverClient.Create(context.Background(), &vsr)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error creating volumesnapshotrestore CR")

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -316,8 +316,7 @@ func GetVolumeSnapshotbackupWithStatusData(volumeSnapshotbackupNS string, volume
 			return false, errors.Wrapf(err, fmt.Sprintf("failed to get volumesnapshotbackup %s/%s", volumeSnapshotbackupNS, volumeSnapshotName))
 		}
 
-		// TODO: Add wait for storageclass and volumesnapshotclass as well, once its support gets merged
-		if len(vsb.Status.ResticRepository) == 0 || len(vsb.Status.SourcePVCData.Name) == 0 || len(vsb.Status.SourcePVCData.Size) == 0 {
+		if len(vsb.Status.ResticRepository) == 0 || len(vsb.Status.SourcePVCData.Name) == 0 || len(vsb.Status.SourcePVCData.Size) == 0 || len(vsb.Status.SourcePVCData.StorageClassName) == 0 || len(vsb.Status.VolumeSnapshotClassName) == 0 {
 			log.Infof("Waiting for volumesnapshotbackup %s/%s to have status data. Retrying in %ds", volumeSnapshotbackupNS, volumeSnapshotName, interval/time.Second)
 			return false, nil
 		}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -298,8 +298,8 @@ func HasBackupLabel(o *metav1.ObjectMeta, backupName string) bool {
 	return o.Labels[velerov1api.BackupNameLabel] == label.GetValidName(backupName)
 }
 
-// Get VolumeSnapshotBackup CR with complete status fields
-func GetVolumeSnapshotbackupWithCompletedStatus(volumeSnapshotbackupNS string, volumeSnapshotName string, log logrus.FieldLogger) (datamoverv1alpha1.VolumeSnapshotBackup, error) {
+// Get VolumeSnapshotBackup CR with status data
+func GetVolumeSnapshotbackupWithStatusData(volumeSnapshotbackupNS string, volumeSnapshotName string, log logrus.FieldLogger) (datamoverv1alpha1.VolumeSnapshotBackup, error) {
 
 	timeout := 10 * time.Minute
 	interval := 5 * time.Second
@@ -316,8 +316,8 @@ func GetVolumeSnapshotbackupWithCompletedStatus(volumeSnapshotbackupNS string, v
 			return false, errors.Wrapf(err, fmt.Sprintf("failed to get volumesnapshotbackup %s/%s", volumeSnapshotbackupNS, volumeSnapshotName))
 		}
 
-		if len(vsb.Status.Phase) == 0 || vsb.Status.Phase != datamoverv1alpha1.SnapMoverBackupPhaseCompleted {
-			log.Infof("Waiting for volumesnapshotbackup %s/%s to complete. Retrying in %ds", volumeSnapshotbackupNS, volumeSnapshotName, interval/time.Second)
+		if len(vsb.Status.ResticRepository) == 0 || len(vsb.Status.SourcePVCData.Name) == 0 || len(vsb.Status.SourcePVCData.Size) == 0 {
+			log.Infof("Waiting for volumesnapshotbackup %s/%s to have status data. Retrying in %ds", volumeSnapshotbackupNS, volumeSnapshotName, interval/time.Second)
 			return false, nil
 		}
 
@@ -331,7 +331,7 @@ func GetVolumeSnapshotbackupWithCompletedStatus(volumeSnapshotbackupNS string, v
 		}
 		return vsb, err
 	}
-	log.Infof("Return VSB from GetVolumeSnapshotbackupWithCompletedStatus: %v", vsb)
+	log.Infof("Return VSB from GetVolumeSnapshotbackupWithInProgressStatus: %v", vsb)
 	return vsb, nil
 }
 

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -316,6 +316,7 @@ func GetVolumeSnapshotbackupWithStatusData(volumeSnapshotbackupNS string, volume
 			return false, errors.Wrapf(err, fmt.Sprintf("failed to get volumesnapshotbackup %s/%s", volumeSnapshotbackupNS, volumeSnapshotName))
 		}
 
+		// TODO: Add wait for storageclass and volumesnapshotclass as well, once its support gets merged
 		if len(vsb.Status.ResticRepository) == 0 || len(vsb.Status.SourcePVCData.Name) == 0 || len(vsb.Status.SourcePVCData.Size) == 0 {
 			log.Infof("Waiting for volumesnapshotbackup %s/%s to have status data. Retrying in %ds", volumeSnapshotbackupNS, volumeSnapshotName, interval/time.Second)
 			return false, nil


### PR DESCRIPTION
The VolumeSnapshotBackupBackupItemAction plugin now does not wait for the VSB to complete, its just waits for the VSR restore relevant data to be populated on the status, this improves the performance as the plugin does not wait for the VSB to complete, this blocking action is now transferred to Velero core just before the end of Backup completion.
Related Velero PR: https://github.com/openshift/velero/pull/177
Fixes: https://github.com/konveyor/volume-snapshot-mover/issues/98