### PR TITLE
OADP-645: VSR performance improvements 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
 	golang.org/x/net v0.0.0-20210825183410-e898025ed96a // indirect
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect
+	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	golang.org/x/sys v0.0.0-20211029165221-6e7872819dc8 // indirect
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -869,6 +869,8 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 h1:uVc8UZUe6tr40fFVnUP5Oj+veunVezqYl9z7DYw9xzw=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/backup/volumesnapshotbackup_action.go
+++ b/internal/backup/volumesnapshotbackup_action.go
@@ -73,7 +73,8 @@ func (p *VolumeSnapshotBackupBackupItemAction) Execute(item runtime.Unstructured
 				util.WaitVolumeSnapshotBackup: "true",
 			},
 		},
-		Driver:         "ebs.csi.aws.com",
+		// dummy driver as it is not used, but the field is required
+		Driver:         "foo",
 		DeletionPolicy: "Retain",
 	}
 
@@ -85,10 +86,10 @@ func (p *VolumeSnapshotBackupBackupItemAction) Execute(item runtime.Unstructured
 	_, err = snapshotClient.SnapshotV1().VolumeSnapshotClasses().Create(context.TODO(), &tempVSC, metav1.CreateOptions{})
 
 	if apierrors.IsAlreadyExists(err) {
-		p.Log.Infof("skipping creation of volumesnapshotclass %v as already exists", tempVSC.Name)
+		p.Log.Infof("skipping creation of temp volumesnapshotclass %v as already exists", tempVSC.Name)
 
 	} else if err != nil {
-		return nil, nil, errors.Wrapf(err, "error creating volumesnapshotclass")
+		return nil, nil, errors.Wrapf(err, "error creating temp volumesnapshotclass")
 	}
 
 	additionalItems := []velero.ResourceIdentifier{}

--- a/internal/restore/volumesnapshotclass_action.go
+++ b/internal/restore/volumesnapshotclass_action.go
@@ -17,6 +17,8 @@ limitations under the License.
 package restore
 
 import (
+	"strconv"
+
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
@@ -49,6 +51,23 @@ func (p *VolumeSnapshotClassRestoreItemAction) Execute(input *velero.RestoreItem
 
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(input.Item.UnstructuredContent(), &snapClass); err != nil {
 		return &velero.RestoreItemActionExecuteOutput{}, errors.Wrapf(err, "failed to convert input.Item from unstructured")
+	}
+
+	// check whether or not this VSClass is for blocking VSR until completed
+	isHasWait := snapClass.Labels[util.WaitVolumeSnapshotBackup]
+	boolIsWait, err := strconv.ParseBool(isHasWait)
+	if err != nil {
+		return nil, err
+	}
+
+	// block until all VSRs from this restore name are completed or timeout
+	// when completed do not restore this dummy VSClass
+	if boolIsWait {
+		util.WaitForDataMoverRestoreToComplete(snapClass.Labels[util.RestoreNameLabel], p.Log)
+
+		return &velero.RestoreItemActionExecuteOutput{
+			SkipRestore: true,
+		}, nil
 	}
 
 	additionalItems := []velero.ResourceIdentifier{}

--- a/internal/restore/volumesnapshotclass_action.go
+++ b/internal/restore/volumesnapshotclass_action.go
@@ -55,18 +55,12 @@ func (p *VolumeSnapshotClassRestoreItemAction) Execute(input *velero.RestoreItem
 
 	// check whether or not this VSClass is for blocking VSR until completed
 	vsClassHasWait := snapClass.Labels[util.WaitVolumeSnapshotBackup]
-	boolHasWait, err := strconv.ParseBool(vsClassHasWait)
-	if err != nil {
-		return nil, err
-	}
+	boolHasWait, _ := strconv.ParseBool(vsClassHasWait)
 
 	// block until all VSRs from this restore name are completed or timeout
-	// when completed do not restore this VSClass
+	// when completed do not restore this temp VSClass
 	if boolHasWait {
-		// TODO: remove this log
-		p.Log.Info("Blocking until all VSRs are completed")
-
-		util.WaitForDataMoverRestoreToComplete(snapClass.Labels[util.RestoreNameLabel], p.Log)
+		util.WaitForDataMoverRestoreToComplete(input.Restore.Name, p.Log)
 
 		return &velero.RestoreItemActionExecuteOutput{
 			SkipRestore: true,

--- a/internal/restore/volumesnapshotclass_action.go
+++ b/internal/restore/volumesnapshotclass_action.go
@@ -54,15 +54,18 @@ func (p *VolumeSnapshotClassRestoreItemAction) Execute(input *velero.RestoreItem
 	}
 
 	// check whether or not this VSClass is for blocking VSR until completed
-	isHasWait := snapClass.Labels[util.WaitVolumeSnapshotBackup]
-	boolIsWait, err := strconv.ParseBool(isHasWait)
+	vsClassHasWait := snapClass.Labels[util.WaitVolumeSnapshotBackup]
+	boolHasWait, err := strconv.ParseBool(vsClassHasWait)
 	if err != nil {
 		return nil, err
 	}
 
 	// block until all VSRs from this restore name are completed or timeout
-	// when completed do not restore this dummy VSClass
-	if boolIsWait {
+	// when completed do not restore this VSClass
+	if boolHasWait {
+		// TODO: remove this log
+		p.Log.Info("Blocking until all VSRs are completed")
+
 		util.WaitForDataMoverRestoreToComplete(snapClass.Labels[util.RestoreNameLabel], p.Log)
 
 		return &velero.RestoreItemActionExecuteOutput{

--- a/internal/restore/volumesnapshotrestore_action.go
+++ b/internal/restore/volumesnapshotrestore_action.go
@@ -81,18 +81,6 @@ func (p *VolumeSnapshotRestoreRestoreItemAction) Execute(input *velero.RestoreIt
 	}
 	p.Log.Infof("[vsb-restore] vsr created: %s", vsr.Name)
 
-	// block until VSR is completed for VolSync VSC handle
-	// volSnapshotRestoreCompleted, err := util.GetVolumeSnapshotRestoreWithCompletedStatus(vsr.Namespace, vsr.Name, vsr.Spec.ProtectedNamespace, p.Log)
-	// if err != nil {
-	// 	return nil, errors.WithStack(err)
-	// }
-
-	// if !volSnapshotRestoreCompleted {
-	// 	return nil, errors.New("volumeSnapshotRestore has not completed")
-	// }
-
-	//p.Log.Infof("[vsb-restore] VSR completed: %s", vsr.Name)
-
 	// don't restore VSB
 	return &velero.RestoreItemActionExecuteOutput{
 		SkipRestore: true,

--- a/internal/restore/volumesnapshotrestore_action.go
+++ b/internal/restore/volumesnapshotrestore_action.go
@@ -2,6 +2,7 @@ package restore
 
 import (
 	"context"
+
 	datamoverv1alpha1 "github.com/konveyor/volume-snapshot-mover/api/v1alpha1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -81,16 +82,16 @@ func (p *VolumeSnapshotRestoreRestoreItemAction) Execute(input *velero.RestoreIt
 	p.Log.Infof("[vsb-restore] vsr created: %s", vsr.Name)
 
 	// block until VSR is completed for VolSync VSC handle
-	volSnapshotRestoreCompleted, err := util.GetVolumeSnapshotRestoreWithCompletedStatus(vsr.Namespace, vsr.Name, vsr.Spec.ProtectedNamespace, p.Log)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
+	// volSnapshotRestoreCompleted, err := util.GetVolumeSnapshotRestoreWithCompletedStatus(vsr.Namespace, vsr.Name, vsr.Spec.ProtectedNamespace, p.Log)
+	// if err != nil {
+	// 	return nil, errors.WithStack(err)
+	// }
 
-	if !volSnapshotRestoreCompleted {
-		return nil, errors.New("volumeSnapshotRestore has not completed")
-	}
+	// if !volSnapshotRestoreCompleted {
+	// 	return nil, errors.New("volumeSnapshotRestore has not completed")
+	// }
 
-	p.Log.Infof("[vsb-restore] VSR completed: %s", vsr.Name)
+	//p.Log.Infof("[vsb-restore] VSR completed: %s", vsr.Name)
 
 	// don't restore VSB
 	return &velero.RestoreItemActionExecuteOutput{

--- a/internal/util/labels_annotations.go
+++ b/internal/util/labels_annotations.go
@@ -42,6 +42,7 @@ const (
 	VolumeSnapshotMoverSourcePVCSize         = "datamover.io/source-pvc-size"
 	VolumeSnapshotMoverSourcePVCStorageClass = "datamover.io/source-pvc-storageclass"
 	VolumeSnapshotMoverVolumeSnapshotClass   = "datamover.io/source-pvc-volumesnapshotclass"
+	WaitVolumeSnapshotBackup                 = "datamover.io/wait-for-vsb"
 
 	// Env vars
 	VolumeSnapshotMoverEnv = "VOLUME_SNAPSHOT_MOVER"


### PR DESCRIPTION
image: `quay.io/emcmulla/csi-plugin:perf`

To test: 
- take backup using data mover of an app with multiple PVCs, such as robot-shop
- delete app and VSCs after backup completes
- in DPA, override CSI image with `quay.io/emcmulla/csi-plugin:perf` and Velero image with  `quay.io/emcmulla/velero:perf`
- create restore with data mover
- in Velero logs, you should notice waiting for all VSRs to complete simultaneously 