### PR TITLE
OADP-794: [cherry-pick oadp-1.1] Fix: Restore of an already restored PVC

### DIFF
--- a/internal/restore/pvc_action.go
+++ b/internal/restore/pvc_action.go
@@ -70,11 +70,13 @@ func resetPVCSpec(pvc *corev1api.PersistentVolumeClaim, vsName string) {
 	// Restore operation for the PVC will use the volumesnapshot as the data source.
 	// So clear out the volume name, which is a ref to the PV
 	pvc.Spec.VolumeName = ""
-	pvc.Spec.DataSource = &corev1api.TypedLocalObjectReference{
+	dataSourceRef := &corev1api.TypedLocalObjectReference{
 		APIGroup: &snapshotv1api.SchemeGroupVersion.Group,
 		Kind:     "VolumeSnapshot",
 		Name:     vsName,
 	}
+	pvc.Spec.DataSource = dataSourceRef
+	pvc.Spec.DataSourceRef = dataSourceRef
 }
 
 func setPVCStorageResourceRequest(pvc *corev1api.PersistentVolumeClaim, restoreSize resource.Quantity, log logrus.FieldLogger) {

--- a/internal/restore/pvc_action_test.go
+++ b/internal/restore/pvc_action_test.go
@@ -206,6 +206,10 @@ func TestResetPVCSpec(t *testing.T) {
 						Kind: "something-that-does-not-exist",
 						Name: "not-found",
 					},
+					DataSourceRef: &corev1api.TypedLocalObjectReference{
+						Kind: "something-that-does-not-exist",
+						Name: "not-found",
+					},
 				},
 			},
 			vsName: "test-vs",
@@ -227,6 +231,7 @@ func TestResetPVCSpec(t *testing.T) {
 			assert.NotNil(t, tc.pvc.Spec.DataSource, "expected change to Spec.DataSource missing")
 			assert.Equalf(t, tc.pvc.Spec.DataSource.Kind, "VolumeSnapshot", "expected change to Spec.DataSource.Kind missing, Want: VolumeSnapshot, Got: %s", tc.pvc.Spec.DataSource.Kind)
 			assert.Equalf(t, tc.pvc.Spec.DataSource.Name, tc.vsName, "expected change to Spec.DataSource.Name missing, Want: %s, Got: %s", tc.vsName, tc.pvc.Spec.DataSource.Name)
+			assert.Equalf(t, tc.pvc.Spec.DataSourceRef.Name, tc.vsName, "expected change to Spec.DataSourceRef.Name missing, Want: %s, Got: %s", tc.vsName, tc.pvc.Spec.DataSourceRef.Name)
 		})
 	}
 }


### PR DESCRIPTION
Consider doing a restore of a PVC that was created from a dataSource; Since k8s 1.24, it will have both dataSource and dataSourceRef populated and equal: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#data-source-references This becomes a problem here because we will carry over the older PVC's dataSourceRef, combined with the "new" dataSource, resulting in rejection.

Fixes https://github.com/vmware-tanzu/velero/issues/5404

Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>
(cherry picked from commit 72ad2ed0fbfe2218b658fee5d4a445f678159610)