### PR TITLE
DNM: update golang to 1.25.3 for future CVE

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -1,4 +1,4 @@
-FROM quay.io/konveyor/builder:ubi9-v1.23 AS builder
+FROM quay.io/konveyor/builder:ubi9-v1.25.3 AS builder
 ENV GOPATH=$APP_ROOT
 COPY . $APP_ROOT/src/velero-plugin-for-csi
 WORKDIR $APP_ROOT/src/velero-plugin-for-csi

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/vmware-tanzu/velero-plugin-for-csi
 
-go 1.23.0
-
-toolchain go1.23.6
+go 1.25.3
 
 require (
 	github.com/evanphx/json-patch v5.6.0+incompatible


### PR DESCRIPTION
## Summary
- Update go.mod from go 1.23.0/toolchain go1.23.6 to go 1.25.3/toolchain go1.25.3
- Update Dockerfile.ubi builder image from `quay.io/konveyor/builder:ubi9-v1.23` to `quay.io/konveyor/builder:ubi9-v1.25.3`
- Ran `go mod tidy` to reconcile dependencies

## Test plan
- [ ] Verify `go build ./...` succeeds locally (done)
- [ ] Verify container build with `quay.io/konveyor/builder:ubi9-v1.25.3`
- [ ] Run unit tests
- [ ] Run e2e tests

Made with [Cursor](https://cursor.com)